### PR TITLE
chore: promote golang-http to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-deploy.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-deploy.yaml
@@ -1,0 +1,61 @@
+# Source: golang-http/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: golang-http-golang-http
+  labels:
+    draft: draft-app
+    chart: "golang-http-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'golang-http'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: golang-http-golang-http
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: golang-http-golang-http
+    spec:
+      serviceAccountName: golang-http-golang-http
+      containers:
+        - name: golang-http
+          image: "10.99.17.162:80/m070888/golang-http:0.0.4"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.4
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:
+        - name: "tekton-container-registry-auth"

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-sa.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-sa.yaml
@@ -1,0 +1,10 @@
+# Source: golang-http/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: golang-http-golang-http
+  annotations:
+    meta.helm.sh/release-name: 'golang-http'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-ingress.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-ingress.yaml
@@ -1,0 +1,19 @@
+# Source: golang-http/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'golang-http'
+  name: golang-http
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              serviceName: golang-http
+              servicePort: 80
+      host: golang-http-jx-staging.10.0.2.15.nip.io

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-svc.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-svc.yaml
@@ -1,0 +1,20 @@
+# Source: golang-http/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: golang-http
+  labels:
+    chart: "golang-http-0.0.4"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'golang-http'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: golang-http-golang-http

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,15 @@
 	      <td></td>
 	      <td><a href='https://github.com/cdfoundation/tekton-helm-chart'>source</a></td>
 	    </tr>
+    <tr>
+		      <td colspan='4'><h3>jx-staging</h3></td>
+		    </tr>
+	    <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> golang-http </a></td>
+	      <td>0.0.4</td>
+	      <td><a href='http://golang-http-jx-staging.10.0.2.15.nip.io'>view</a></td>
+	      <td></td>
+	    </tr>
 
   </tbody>
 </table>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -119,3 +119,21 @@
     repositoryUrl: https://cdfoundation.github.io/tekton-helm-chart
     resourcePath: config-root/namespaces/tekton-pipelines/tekton-pipeline
     version: 0.24.4
+- namespace: jx-staging
+  path: helmfiles/jx-staging/helmfile.yaml
+  releases:
+  - apiVersion: v1
+    appVersion: 0.0.4
+    applicationUrl: http://golang-http-jx-staging.10.0.2.15.nip.io
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2021-07-09T05:23:07Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    ingresses:
+    - name: golang-http
+      url: http://golang-http-jx-staging.10.0.2.15.nip.io
+    lastDeployed: "2021-07-09T05:23:07Z"
+    name: golang-http
+    repositoryName: dev
+    repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
+    resourcePath: config-root/namespaces/jx-staging/golang-http
+    version: 0.0.4

--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -2,5 +2,6 @@ filepath: ""
 helmfiles:
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+- path: helmfiles/jx-staging/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/golang-http
-  version: 0.0.2
+  version: 0.0.4
   name: golang-http
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote golang-http to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
