### PR TITLE
chore: promote golang-http to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-deploy.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-golang-http-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: golang-http-golang-http
   labels:
     draft: draft-app
-    chart: "golang-http-0.0.4"
+    chart: "golang-http-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'golang-http'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: golang-http-golang-http
       containers:
         - name: golang-http
-          image: "10.99.17.162:80/m070888/golang-http:0.0.4"
+          image: "10.99.17.162:80/m070888/golang-http:0.0.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.5
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/golang-http/golang-http-svc.yaml
+++ b/config-root/namespaces/jx-staging/golang-http/golang-http-svc.yaml
@@ -4,13 +4,13 @@ kind: Service
 metadata:
   name: golang-http
   labels:
-    chart: "golang-http-0.0.4"
+    chart: "golang-http-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'golang-http'
   namespace: jx-staging
 spec:
-  type: ClusterIP
+  type: nodeport
   ports:
     - port: 80
       targetPort: 8080

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@
 		    </tr>
 	    <tr>
 	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> golang-http </a></td>
-	      <td>0.0.4</td>
+	      <td>0.0.5</td>
 	      <td><a href='http://golang-http-jx-staging.10.0.2.15.nip.io'>view</a></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -123,17 +123,17 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.4
+    appVersion: 0.0.5
     applicationUrl: http://golang-http-jx-staging.10.0.2.15.nip.io
     description: A Helm chart for Kubernetes
-    firstDeployed: "2021-07-09T05:23:07Z"
+    firstDeployed: "2021-07-09T05:42:04Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
     ingresses:
     - name: golang-http
       url: http://golang-http-jx-staging.10.0.2.15.nip.io
-    lastDeployed: "2021-07-09T05:23:07Z"
+    lastDeployed: "2021-07-09T05:42:04Z"
     name: golang-http
     repositoryName: dev
     repositoryUrl: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
     resourcePath: config-root/namespaces/jx-staging/golang-http
-    version: 0.0.4
+    version: 0.0.5

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/golang-http
-  version: 0.0.4
+  version: 0.0.5
   name: golang-http
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote golang-http to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
